### PR TITLE
feat: add entity name normalization for better UX

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -5,7 +5,7 @@ import ComplaintReport from "./components/ComplaintReport";
 import CaptchaForm from "./components/CaptchaForm";
 
 function App() {
-  // Entidades deben coincidir con los ENUM en tu backend
+  
   const entities = [
     "GOBERNACION_BOYACA",
     "SECRETARIA_EDUCACION",
@@ -14,6 +14,19 @@ function App() {
     "ALCALDIA_DUITAMA",
     "ALCALDIA_SOGAMOSO",
   ];
+
+  const normalizeEntityName = (entityCode) => {
+    const entityNames = {
+      "GOBERNACION_BOYACA": "Gobernación de Boyacá",
+      "SECRETARIA_EDUCACION": "Secretaría de Educación",
+      "SECRETARIA_SALUD": "Secretaría de Salud",
+      "ALCALDIA_TUNJA": "Alcaldía de Tunja",
+      "ALCALDIA_DUITAMA": "Alcaldía de Duitama",
+      "ALCALDIA_SOGAMOSO": "Alcaldía de Sogamoso",
+    };
+
+    return entityNames[entityCode] || entityCode.replace(/_/g, " ");
+  }
 
   const [currentPage, setCurrentPage] = useState("home");
 
@@ -73,10 +86,15 @@ function App() {
       </div>
 
       {/* Contenido dinámico */}
-      {currentPage === "list" && <ComplaintList entities={entities} />}
+      {currentPage === "list" && (
+        <ComplaintList 
+          entities={entities} 
+          normalizeEntityName={normalizeEntityName}
+        />)}
       {currentPage === "form" && (
         <ComplaintForm
           entities={entities}
+          normalizeEntityName={normalizeEntityName}
           onComplaintAdded={() => setCurrentPage("list")}
         />
       )}
@@ -87,20 +105,23 @@ function App() {
         </div>
       )}
       {currentPage === "report" && captchaPassed && (
-        <ComplaintReport entities={entities} />
+        <ComplaintReport 
+          entities={entities}
+          normalizeEntityName={normalizeEntityName}
+        />
       )}
       {currentPage === "home" && <p>👈 Selecciona una opción para comenzar.</p>}
     </div>
   );
 
-  function App() {
+  /*function App() {
     return (
       <div>
         <h1>Mi App con Captcha</h1>
         <CaptchaForm />
       </div>
     );
-  }
+  }*/
 }
 
 export default App;

--- a/src/frontend/src/components/ComplaintForm.jsx
+++ b/src/frontend/src/components/ComplaintForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import axios from "axios";
 
-function ComplaintForm({ entities, onComplaintAdded }) {
+function ComplaintForm({ entities, onComplaintAdded, normalizeEntityName }) {
   const [entity, setEntity] = useState(entities[0]);
   const [text, setText] = useState("");
 
@@ -39,7 +39,7 @@ function ComplaintForm({ entities, onComplaintAdded }) {
       >
         {entities.map((ent, i) => (
           <option key={i} value={ent}>
-            {ent}
+            {normalizeEntityName(ent)}
           </option>
         ))}
       </select>

--- a/src/frontend/src/components/ComplaintList.jsx
+++ b/src/frontend/src/components/ComplaintList.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 
-function ComplaintListByEntity({ entities }) {
+function ComplaintListByEntity({ entities, normalizeEntityName }) {
   const [selectedEntity, setSelectedEntity] = useState(entities[0]);
   const [complaints, setComplaints] = useState([]);
 
@@ -22,12 +22,12 @@ function ComplaintListByEntity({ entities }) {
       >
         {entities.map((ent, i) => (
           <option key={i} value={ent}>
-            {ent}
+            {normalizeEntityName(ent)}
           </option>
         ))}
       </select>
 
-      <h2>📑 Quejas registradas para: {selectedEntity}</h2>
+      <h2>📑 Quejas registradas para: {normalizeEntityName(selectedEntity)}</h2>
       {complaints.length === 0 ? (
         <p>No hay quejas registradas para esta entidad.</p>
       ) : (

--- a/src/frontend/src/components/ComplaintReport.jsx
+++ b/src/frontend/src/components/ComplaintReport.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 
-function ComplaintReport({ entities }) {
+function ComplaintReport({ entities, normalizeEntityName }) {
   const [complaints, setComplaints] = useState([]);
 
   useEffect(() => {
@@ -29,7 +29,7 @@ function ComplaintReport({ entities }) {
         <tbody>
           {report.map((r, i) => (
             <tr key={i}>
-              <td>{r.entity}</td>
+              <td>{normalizeEntityName(r.entity)}</td>
               <td>{r.count}</td>
             </tr>
           ))}


### PR DESCRIPTION
## Cambios
- Implementada normalización de nombres de entidades
- Los usuarios ahora ven "Alcaldía de Tunja" en lugar de "ALCALDIA_TUNJA"
- Aplicado en formularios, listas y reportes
- Mantiene compatibilidad total con el backend

## Beneficio
Mejora significativa en la experiencia de usuario con nombres institucionales legibles y profesionales.