### PR TITLE
fix (frontend): correccion rutas de conexion entre back y front

### DIFF
--- a/src/frontend/src/components/ComplaintForm.jsx
+++ b/src/frontend/src/components/ComplaintForm.jsx
@@ -14,7 +14,7 @@ function ComplaintForm({ entities, onComplaintAdded, normalizeEntityName }) {
     }
 
     try {
-      const response = await axios.post(`${API_URL}/complaints`, {
+      const response = await axios.post(`${API_URL}/api/complaints`, {
         entity,
         text,
       });

--- a/src/frontend/src/components/ComplaintList.jsx
+++ b/src/frontend/src/components/ComplaintList.jsx
@@ -8,7 +8,7 @@ function ComplaintListByEntity({ entities, normalizeEntityName }) {
   
   useEffect(() => {
     axios
-      .get(`${API_URL}/complaints/${selectedEntity}`)
+      .get(`${API_URL}/api/complaints/${selectedEntity}`)
       .then((res) => setComplaints(res.data))
       .catch((err) => console.error(err));
   }, [selectedEntity]);

--- a/src/frontend/src/components/ComplaintReport.jsx
+++ b/src/frontend/src/components/ComplaintReport.jsx
@@ -7,7 +7,7 @@ function ComplaintReport({ entities, normalizeEntityName }) {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/complaints`)
+      .get(`${API_URL}/api/complaints`)
       .then((res) => setComplaints(res.data))
       .catch((err) => console.error(err));
   }, []);


### PR DESCRIPTION
Se corrigieron las rutas de conexión entre el frontend y el backend.  
Anteriormente, el frontend estaba enviando solicitudes a endpoints que no existían en el backend, lo que generaba errores de comunicación.  

## Cambios realizados  
- Ajuste de las rutas para que coincidan con las definidas en el backend.  
- Verificación de las llamadas existentes para evitar endpoints inválidos. 